### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Filters Allowlist Compiler
+permissions:
+  contents: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/SystemJargon/filters/security/code-scanning/4](https://github.com/SystemJargon/filters/security/code-scanning/4)

To fix the problem, you need to add an explicit `permissions` key to the workflow YAML file. The recommended approach is to set the permissions globally, just after the workflow `name` (and before `on:`) so all jobs inherit those settings. The least privilege required is `contents: write`, as the workflow writes commits back to the repository (`EndBug/add-and-commit`). If future jobs need different permissions, job-level overrides can be added later.

Specifically, in `.github/workflows/main.yml`, add:
```yaml
permissions:
  contents: write
```
as line 2, immediately after `name: Filters Allowlist Compiler`. This ensures the workflow does not default to excessive privileges and aligns with the principle of least privilege.

No new imports, definitions, or methods are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
